### PR TITLE
Fix title UI in PostsList component

### DIFF
--- a/frontend/src/app/PostsList.tsx
+++ b/frontend/src/app/PostsList.tsx
@@ -38,7 +38,7 @@ export default function PostsList() {
       <ul className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
         {posts.map((post) => (
           <li key={post.id} className="p-4 border rounded shadow">
-            <h2 className="text-xl font-semibold">{post.title}</h2>
+            <h2 className="text-xl font-semibold whitespace-nowrap overflow-hidden text-ellipsis max-w-full">{post.title}</h2>
             <img
               src={post.image_url}
               alt={post.title}


### PR DESCRIPTION
Update the UI for post titles in the `PostsList` component to truncate long titles with ellipsis.

* Modify the `h2` element in `frontend/src/app/PostsList.tsx` to include Tailwind CSS classes `whitespace-nowrap`, `overflow-hidden`, `text-ellipsis`, and `max-w-full` to ensure titles are displayed in a single line with ellipsis.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Kaiwa-Jun/rails-nextjs-sampleApp/pull/40?shareId=a89238fd-c246-4737-9b2a-64fc253141e8).