### PR TITLE
Update background color to lighter blue and post tiles to white

### DIFF
--- a/backend/app/views/pwa/manifest.json.erb
+++ b/backend/app/views/pwa/manifest.json.erb
@@ -17,6 +17,6 @@
   "display": "standalone",
   "scope": "/",
   "description": "App.",
-  "theme_color": "red",
-  "background_color": "red"
+  "theme_color": "#E0F7FA",
+  "background_color": "#E0F7FA"
 }

--- a/backend/public/404.html
+++ b/backend/public/404.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <style>
   .rails-default-error-page {
-    background-color: #EFEFEF;
+    background-color: #E0F7FA;
     color: #2E2F30;
     text-align: center;
     font-family: arial, sans-serif;

--- a/backend/public/406-unsupported-browser.html
+++ b/backend/public/406-unsupported-browser.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <style>
   .rails-default-error-page {
-    background-color: #EFEFEF;
+    background-color: #E0F7FA;
     color: #2E2F30;
     text-align: center;
     font-family: arial, sans-serif;

--- a/backend/public/422.html
+++ b/backend/public/422.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <style>
   .rails-default-error-page {
-    background-color: #EFEFEF;
+    background-color: #E0F7FA;
     color: #2E2F30;
     text-align: center;
     font-family: arial, sans-serif;

--- a/backend/public/500.html
+++ b/backend/public/500.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <style>
   .rails-default-error-page {
-    background-color: #EFEFEF;
+    background-color: #E0F7FA;
     color: #2E2F30;
     text-align: center;
     font-family: arial, sans-serif;

--- a/frontend/src/app/PostsList.tsx
+++ b/frontend/src/app/PostsList.tsx
@@ -37,7 +37,7 @@ export default function PostsList() {
     {posts.length > 0 ? (
       <ul className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
         {posts.map((post) => (
-          <li key={post.id} className="p-4 rounded shadow transition-transform transform hover:scale-105 hover:brightness-110">
+          <li key={post.id} className="p-4 rounded shadow transition-transform transform hover:scale-105 hover:brightness-110 bg-white">
             <h2 className="text-xl font-semibold whitespace-nowrap overflow-hidden text-ellipsis max-w-full">{post.title}</h2>
             <img
               src={post.image_url}

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -5,6 +5,7 @@
 :root {
   --background: #ffffff;
   --foreground: #171717;
+  --background-light-blue: #E0F7FA;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -16,6 +17,6 @@
 
 body {
   color: var(--foreground);
-  background: var(--background);
+  background: var(--background-light-blue);
   font-family: Arial, Helvetica, sans-serif;
 }


### PR DESCRIPTION
Update background color and post tile background color for better contrast.

* Add a new CSS variable `--background-light-blue: #E0F7FA` to the `:root` selector in `frontend/src/app/globals.css`.
* Update the `background` property in the `body` selector in `frontend/src/app/globals.css` to use the `--background-light-blue` variable.
* Update the background color for error pages in `backend/public/404.html`, `backend/public/406-unsupported-browser.html`, `backend/public/422.html`, and `backend/public/500.html` to `#E0F7FA`.
* Update the `theme_color` and `background_color` in `backend/app/views/pwa/manifest.json.erb` to `#E0F7FA`.
* Add a CSS class to the `li` element inside the `ul` element in `frontend/src/app/PostsList.tsx` to set the background color to white.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Kaiwa-Jun/rails-nextjs-sampleApp/pull/43?shareId=0472bb5b-4114-4bc9-bf20-9de49f4bf1bb).