### PR TITLE
Enable hot-reloading for frontend

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,8 +25,8 @@ services:
     container_name: next_app
     ports:
       - '3001:3000'
-    # volumes:
-    #   - ./frontend:/app
+    volumes:
+      - ./frontend:/app
     depends_on:
       - backend
 


### PR DESCRIPTION
Enable hot reloading for the frontend service in the Docker setup.

* Uncomment the `volumes` section in the `frontend` service in `docker-compose.yml` to mount the local directory to the container.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Kaiwa-Jun/rails-nextjs-sampleApp/pull/46?shareId=057d2dd9-9c6d-49b5-b38b-856ac562cb69).